### PR TITLE
Extend levels and add end-level trophies

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@ const state={
 };
 
 // Camera
-let camX=0;
+let camX=0, levelLength=2000;
 
 // Physics
 const G=0.25, JUMP=-4.5, SPEED=1.3, MAX_FALL=5;
@@ -72,17 +72,28 @@ const themes=[
 // Simple tile map generator per level (platforms array)
 function buildLevel(lv){
   const platforms=[]; // rects {x,y,w,h}
-  // base floor
-  platforms.push({x:-50,y:160,w:2000,h:20});
-  // some steps
-  for(let i=0;i<15;i++){
-    const x=60+i*90+ (lv*10);
-    const y=140 - Math.floor(i%3)*20 - lv*5;
-    platforms.push({x,y,w:50,h:6});
+  const len=4000; // overall length per level
+  // base floor spanning the whole stage
+  platforms.push({x:-50,y:160,w:len,h:20});
+  // step platforms to traverse
+  const steps=40 + lv*5;
+  for(let i=0;i<steps;i++){
+    const x=80+i*90;
+    const y=140 - ((i+lv)% (3+lv))*20 - lv*5;
+    platforms.push({x,y,w:60,h:6});
   }
-  // boss arena platform
-  platforms.push({x:1500,y:120 - lv*5,w:120,h:6});
-  return platforms;
+  // boss arena platform near the end
+  platforms.push({x:len-160,y:120 - lv*5,w:120,h:6});
+  return {platforms,len};
+}
+
+// find highest platform surface at a given x
+function groundY(x){
+  let y=200; // default far below stage
+  for(const p of level.platforms){
+    if(x>=p.x && x<=p.x+p.w && p.y<y) y=p.y;
+  }
+  return y;
 }
 
 // Entities
@@ -91,13 +102,14 @@ function mkEnemy(x,y){return {x,y,w:10,h:14,vx:(rng()<.5?-0.6:0.6),type:'punk',a
 function mkPickup(x,y,kind){return {x,y,w:6,h:6,kind,used:false}}
 function mkBullet(x,y,dir){return {x,y,w:6,h:4,vx:dir*2.2,dead:false}}
 
-function mkBoss(level){
+function mkBoss(level, arena){
+  const center=arena.x+arena.w/2;
   if(level===0){ // sand eater: spits sand blobs arcs
-    return {x:1520,y:100,w:20,h:18,hp:6, type:'arena', cd:0, phase:0, vx:0}
+    return {x:center-10,y:arena.y-18,w:20,h:18,hp:6,type:'arena',cd:0,vx:0.7,left:arena.x,right:arena.x+arena.w-20};
   } else if(level===1){ // sausage spitter: straight projectiles
-    return {x:1520,y:100,w:20,h:18,hp:7, type:'salchicha', cd:0, phase:0, vx:0}
+    return {x:center-10,y:arena.y-18,w:20,h:18,hp:7,type:'salchicha',cd:0,vx:0.7,left:arena.x,right:arena.x+arena.w-20};
   } else { // boar: full-screen charges
-    return {x:1520,y:100,w:24,h:16,hp:8, type:'cerdo', cd:90, phase:0, vx:0}
+    return {x:arena.x+arena.w-24,y:arena.y-16,w:24,h:16,hp:8,type:'cerdo',cd:90,vx:0,startX:arena.x+arena.w-24};
   }
 }
 
@@ -105,20 +117,29 @@ function mkBoss(level){
 let level={ platforms:[], enemies:[], pickups:[], bullets:[], boss:null, goal:null, player:null, bossShots:[], cleared:false };
 
 function resetRuntime(){
-  level.platforms=buildLevel(state.level);
+  const map=buildLevel(state.level);
+  level.platforms=map.platforms; levelLength=map.len;
   level.enemies=[]; level.pickups=[]; level.bullets=[]; level.bossShots=[];
-  // populate enemies
-  for(let i=0;i<8;i++){
-    const x=120+i*120, y=140-(i%3)*20 - state.level*5;
-    level.enemies.push(mkEnemy(x,y-14));
+  // populate enemies along the stage
+  const enemyCount=Math.floor(levelLength/150);
+  for(let i=0;i<enemyCount;i++){
+    const x=120+i*150;
+    const y=groundY(x)-14;
+    level.enemies.push(mkEnemy(x,y));
   }
-  // pickups spread
-  const loot=['gin','coin','lighter','coin','gin','coin'];
-  loot.forEach((k,i)=>{
-    const x=140+i*180, y=130-(i%2)*20 - state.level*5;
-    level.pickups.push(mkPickup(x,y,k));
-  });
-  level.boss=mkBoss(state.level);
+  // pickups spread: mostly lighters, few coins/gin
+  const pickupCount=Math.floor(levelLength/120);
+  for(let i=0;i<pickupCount;i++){
+    const x=140+i*120;
+    const y=130-(i%2)*20 - state.level*5;
+    const r=rng();
+    const kind = r<0.6 ? 'lighter' : r<0.8 ? 'coin' : 'gin';
+    level.pickups.push(mkPickup(x,y,kind));
+  }
+  const arena=level.platforms[level.platforms.length-1];
+  level.boss=mkBoss(state.level,arena);
+  // ensure boss rests exactly on its arena platform
+  level.boss.y = arena.y - level.boss.h;
   level.goal=null; level.cleared=false; camX=0;
   level.player=mkPlayer();
 }
@@ -157,14 +178,9 @@ function drawStart(){
   ctx.fillStyle='#101018'; ctx.fillRect(0,0,W,H);
   drawTitle('RETRO ASCENSO');
   drawSub('Plataformas 8-bit · JS+Canvas');
-  renderButtons([
-    {label:'Comenzar', onClick:()=>{state.screen='map'; renderUIButtons()}},
-    {label:'Controles: ←/→ moverse · Espacio saltar · F disparar', small:true}
-  ]);
 }
 
 function drawMap(){
-  const t=themes[state.trophies.filter(Boolean).length];
   ctx.fillStyle='#0e141a'; ctx.fillRect(0,0,W,H);
   // simple mountain triangle
   ctx.fillStyle='#223'; triangle(W/2,H-10, 40, -120);
@@ -178,12 +194,6 @@ function drawMap(){
   }
   drawTitle('Selecciona nivel');
   drawSub(`Nivel actual: ${state.level+1} · ${themes[state.level].name}`);
-  renderButtons([
-    {label:'Jugar nivel', onClick:()=>{startLevel()}},
-    {label:'← Nivel', onClick:()=>{state.level=(state.level+2)%3; renderUIButtons()}},
-    {label:'Nivel →', onClick:()=>{state.level=(state.level+1)%3; renderUIButtons()}},
-    {label:'Inicio', onClick:()=>{state.screen='start'; renderUIButtons()}},
-  ]);
 }
 
 function startLevel(){
@@ -202,13 +212,15 @@ function drawPlay(){
   // pickups
   for(const it of level.pickups){ if(it.used) continue; drawPickup(it) }
   // enemies
-  ctx.fillStyle='#d66'; for(const e of level.enemies){ if(!e.alive) continue; ctx.fillRect(e.x-camX,e.y,e.w,e.h) }
+  for(const e of level.enemies){ if(!e.alive) continue; drawEnemy(e) }
   // boss
   if(level.boss && level.boss.hp>0){ drawBoss(level.boss, theme) }
   // bullets
   ctx.fillStyle=theme.accent; for(const b of level.bullets){ ctx.fillRect(b.x-camX,b.y,b.w,b.h) }
   // boss projectiles
   for(const s of level.bossShots){ ctx.fillStyle=s.col||'#cc4'; ctx.fillRect(s.x-camX,s.y,s.w,s.h) }
+  // goal plant when boss defeated
+  if(level.goal){ ctx.fillStyle=level.goal.col; ctx.fillRect(level.goal.x-camX, level.goal.y, level.goal.w, level.goal.h) }
   // player
   drawPlayer(level.player);
   // HUD
@@ -220,9 +232,6 @@ function drawEnding(){
   ctx.fillStyle='#000'; ctx.fillRect(0,0,W,H);
   drawTitle('¡Has llegado a la cima!');
   drawSub('“Extraño ha sido el viaje, más extraño es volver a la rutina”');
-  renderButtons([
-    {label:'Volver al inicio', onClick:()=>{state.screen='start'; state.trophies=[false,false,false]; state.level=0; state.lives=3; state.shields=0; state.coins=0; state.ammo=0; renderUIButtons();}},
-  ]);
 }
 
 // Rendering helpers
@@ -240,11 +249,30 @@ function shade(hex,amt){ // naive shade
 }
 
 function drawPlayer(p){
-  ctx.fillStyle='#6cf'; ctx.fillRect(p.x-camX,p.y,p.w,p.h);
+  const x=p.x-camX, y=p.y;
+  // legs
+  ctx.fillStyle='#444'; ctx.fillRect(x,y+10,10,4);
+  // body
+  ctx.fillStyle='#6cf'; ctx.fillRect(x,y+4,10,6);
+  // arms
+  ctx.fillRect(x-2,y+5,2,3); ctx.fillRect(x+10,y+5,2,3);
   // head
-  ctx.fillStyle='#fff'; ctx.fillRect(p.x+2-camX,p.y-4,6,4);
-  // direction nose
-  ctx.fillStyle='#9cf'; ctx.fillRect(p.x + (p.dir>0?8:-2) -camX, p.y-2,2,2)
+  ctx.fillStyle='#ffd7b5'; ctx.fillRect(x+2,y-4,6,4);
+  // eyes
+  ctx.fillStyle='#000'; ctx.fillRect(x+(p.dir>0?6:2),y-2,2,2);
+}
+
+function drawEnemy(e){
+  const x=e.x-camX, y=e.y;
+  // legs
+  ctx.fillStyle='#633'; ctx.fillRect(x,y+10,10,4);
+  // body jacket
+  ctx.fillStyle='#d66'; ctx.fillRect(x,y+4,10,6);
+  ctx.fillRect(x-2,y+5,2,3); ctx.fillRect(x+10,y+5,2,3);
+  // head
+  ctx.fillStyle='#ffd7b5'; ctx.fillRect(x+2,y-4,6,4);
+  // punk crest
+  ctx.fillStyle='#f0f'; ctx.fillRect(x+4,y-6,2,2);
 }
 
 function drawPickup(it){
@@ -255,17 +283,17 @@ function drawPickup(it){
 }
 
 function drawBoss(b,theme){
-  if(b.type==='arena'){
-    ctx.fillStyle='#caa';
-  } else if(b.type==='salchicha'){
-    ctx.fillStyle='#a53';
-  } else {
-    ctx.fillStyle='#f7a';
-  }
-  ctx.fillRect(b.x-camX,b.y,b.w,b.h);
+  const x=b.x-camX,y=b.y;
+  const col=b.type==='arena'?'#caa':b.type==='salchicha'?'#a53':'#f7a';
+  // body
+  ctx.fillStyle=col; ctx.fillRect(x,y+4,b.w,b.h-4);
+  // arms
+  ctx.fillRect(x-4,y+6,4,4); ctx.fillRect(x+b.w,y+6,4,4);
+  // head
+  ctx.fillStyle='#ffd7b5'; ctx.fillRect(x+4,y,b.w-8,4);
   // HP bar
   ctx.fillStyle='#000'; ctx.fillRect(10,10,100,4);
-  ctx.fillStyle=theme.accent; ctx.fillRect(10,10, (b.hp/ (b.type==='arena'?6:b.type==='salchicha'?7:8))*100,4);
+  ctx.fillStyle=theme.accent; ctx.fillRect(10,10,(b.hp/(b.type==='arena'?6:b.type==='salchicha'?7:8))*100,4);
 }
 
 // UI Buttons (HTML overlay)
@@ -279,12 +307,22 @@ function renderButtons(list){
   });
 }
 function renderUIButtons(){
-  if(state.screen==='start') return renderButtons([]);
-  if(state.screen==='map') return; // buttons already drawn in drawMap
-  if(state.screen==='play') return renderButtons([
-    {label:'Salir', onClick:()=>{state.screen='map'; hud.classList.add('hidden'); statusBox.classList.add('hidden'); renderUIButtons()}},
+  if(state.screen==='start') return renderButtons([
+    {label:'Comenzar', onClick:()=>{state.screen='map'; renderUIButtons();}},
+    {label:'Controles: ←/→ moverse · Espacio saltar · F disparar', small:true},
   ]);
-  if(state.screen==='ending') return; // ending screen buttons drawn there
+  if(state.screen==='map') return renderButtons([
+    {label:'Jugar nivel', onClick:()=>{startLevel();}},
+    {label:'← Nivel', onClick:()=>{state.level=(state.level+2)%3; renderUIButtons();}},
+    {label:'Nivel →', onClick:()=>{state.level=(state.level+1)%3; renderUIButtons();}},
+    {label:'Inicio', onClick:()=>{state.screen='start'; renderUIButtons();}},
+  ]);
+  if(state.screen==='play') return renderButtons([
+    {label:'Salir', onClick:()=>{state.screen='map'; hud.classList.add('hidden'); statusBox.classList.add('hidden'); renderUIButtons();}},
+  ]);
+  if(state.screen==='ending') return renderButtons([
+    {label:'Volver al inicio', onClick:()=>{state.screen='start'; state.trophies=[false,false,false]; state.level=0; state.lives=3; state.shields=0; state.coins=0; state.ammo=0; renderUIButtons();}},
+  ]);
 }
 
 // Gameplay update
@@ -298,13 +336,20 @@ function updatePlay(){
   p.vy = clamp(p.vy+G, -9, MAX_FALL);
   p.x += p.vx; resolvePlatforms(p);
   p.y += p.vy; resolvePlatforms(p);
-  camX = clamp(p.x-80, 0, 2000-W);
+  camX = clamp(p.x-80, 0, levelLength-W);
   if(p.inv>0) p.inv--;
 
   // enemies AI
-  for(const e of level.enemies){ if(!e.alive) continue; e.x += e.vx; // bounce on platform edges
-    let onPlat=false; for(const pl of level.platforms){ if(e.x>pl.x-2 && e.x<pl.x+pl.w+2 && Math.abs(e.y+e.h - pl.y)<2){ onPlat=true; break } }
-    if(!onPlat || rng()<.01) e.vx*=-1;
+  for(const e of level.enemies){
+    if(!e.alive) continue;
+    e.x += e.vx;
+    let plat=null;
+    for(const pl of level.platforms){
+      if(e.x>=pl.x && e.x+e.w<=pl.x+pl.w && Math.abs(e.y+e.h-pl.y)<2){ plat=pl; break; }
+    }
+    if(!plat){ e.vx*=-1; e.x+=e.vx; }
+    else if(e.x<=plat.x || e.x+e.w>=plat.x+plat.w){ e.vx*=-1; }
+    if(Math.abs(e.vx)<0.2) e.vx=0.6*(rng()<.5?1:-1);
     if(aabb(p,e)) hurtPlayer();
   }
 
@@ -325,14 +370,19 @@ function updatePlay(){
 
   // boss logic
   const B=level.boss; if(B && B.hp>0){
-    B.cd--; if(B.type==='arena'){
-      // spit sand blobs (arcs)
-      if(B.cd<=0){ B.cd=70; for(let i=0;i<3;i++){ level.bossShots.push({x:B.x-2, y:B.y+4, w:4,h:3, vx:-1.2-0.2*i, vy:-2-0.4*i, g:0.08, col:'#d6c18f'})}}
-    } else if(B.type==='salchicha'){
-      if(B.cd<=0){ B.cd=60; for(let i=0;i<4;i++){ level.bossShots.push({x:B.x-2,y:B.y+6,w:5,h:3, vx:-2-(i*0.25), vy:(i-1.5)*0.3, g:0, col:'#d67'})}}
+    B.cd--;
+    if(B.type==='arena' || B.type==='salchicha'){
+      B.x += B.vx;
+      if(B.x<B.left || B.x>B.right){ B.vx*=-1; B.x=clamp(B.x,B.left,B.right); }
+      if(B.type==='arena'){
+        if(B.cd<=0){ B.cd=70; for(let i=0;i<3;i++){ level.bossShots.push({x:B.x-2,y:B.y+4,w:4,h:3,vx:-1.2-0.2*i,vy:-2-0.4*i,g:0.08,col:'#d6c18f'})}}
+      } else {
+        if(B.cd<=0){ B.cd=60; for(let i=0;i<4;i++){ level.bossShots.push({x:B.x-2,y:B.y+6,w:5,h:3,vx:-2-(i*0.25),vy:(i-1.5)*0.3,g:0,col:'#d67'})}}
+      }
     } else { // boar charges
-      if(B.cd<=0){ B.cd=140; B.vx = -3.2; }
-      B.x += B.vx; if(B.x<camX-40){ B.vx=0; B.x=1520 }
+      if(B.cd<=0){ B.cd=140; B.vx=-3.2; }
+      B.x += B.vx;
+      if(B.x<camX-40){ B.vx=0; B.x=B.startX; }
     }
   }
   // boss projectiles update
@@ -343,10 +393,9 @@ function updatePlay(){
   if(B && B.hp>0 && aabb(level.player,B)) hurtPlayer();
 
   // victory -> spawn trophy and exit
-  if(B && B.hp<=0 && !level.cleared){ level.cleared=true; level.goal={x:B.x+10,y:B.y-8,w:6,h:6, col:['#5f5','#fa3','#a5f'][state.level]}; }
-  if(level.cleared){
-    // draw goal handled in draw (as part of pickups? we'll draw here)
-    if(level.goal){ ctx.fillStyle=level.goal.col; ctx.fillRect(level.goal.x-camX, level.goal.y, 6,6); if(aabb(level.player,level.goal)){ state.trophies[state.level]=true; nextAfterClear(); }}
+  if(B && B.hp<=0 && !level.cleared){ level.cleared=true; level.goal={x:B.x+B.w/2-3,y:B.y-10,w:6,h:6,col:['#5f5','#fa3','#a5f'][state.level]}; }
+  if(level.cleared && level.goal){
+    if(aabb(level.player,level.goal)){ state.trophies[state.level]=true; nextAfterClear(); }
   }
 }
 


### PR DESCRIPTION
## Summary
- Generate much longer stages with more platforms
- Scatter mostly lighter pickups and spawn trophy plant after bosses
- Clamp camera to dynamic level length and reset bosses to start position
- Make enemies and bosses patrol and render player and enemies with humanoid sprites
- Spawn enemies on ground surfaces and lock bosses to their arena height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b94981be34832e92eb3250e66dc019