### PR TITLE
Adjust boss arena platform height for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,8 @@ function buildLevel(lv){
     platforms.push({x,y,w:60,h:6});
   }
   // boss arena platform near the end
-  platforms.push({x:len-160,y:120 - lv*5,w:120,h:6});
+  // lower the platform so the player can reach the boss with a single jump
+  platforms.push({x:len-160,y:140 - lv*5,w:120,h:6});
   return {platforms,len};
 }
 


### PR DESCRIPTION
## Summary
- Lower boss arena platform so player can reach final boss with a single jump

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b95c0fb834832e806f3b48cb71cde1