### PR TITLE
feat: add unique backgrounds and platform layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,13 +75,35 @@ function buildLevel(lv){
   const len=4000; // overall length per level
   // base floor spanning the whole stage
   platforms.push({x:-50,y:160,w:len,h:20});
-  // step platforms to traverse
-  const steps=40 + lv*5;
-  for(let i=0;i<steps;i++){
-    const x=80+i*90;
-    const y=140 - ((i+lv)% (3+lv))*20 - lv*5;
-    platforms.push({x,y,w:60,h:6});
+
+  if(lv===0){
+    // urban: regular stair-like ascent
+    const steps=40;
+    for(let i=0;i<steps;i++){
+      const x=80+i*85;
+      const y=140-Math.floor(i/4)*20;
+      platforms.push({x,y,w:70,h:6});
+    }
+  } else if(lv===1){
+    // mountain: wavy natural platforms
+    const steps=55;
+    for(let i=0;i<steps;i++){
+      const x=60+i*70;
+      const y=130-Math.sin(i*0.5)*30;
+      const w=50+(i%3)*10;
+      platforms.push({x,y,w,h:6});
+    }
+  } else {
+    // cave: broken narrow ledges
+    const steps=70;
+    for(let i=0;i<steps;i++){
+      if(i%5===0) continue; // gaps
+      const x=60+i*60;
+      const y=140-(i%3)*25;
+      platforms.push({x,y,w:40,h:6});
+    }
   }
+
   // boss arena platform near the end
   // lower the platform so the player can reach the boss with a single jump
   platforms.push({x:len-160,y:140 - lv*5,w:120,h:6});
@@ -208,11 +230,65 @@ function startLevel(){
   renderUIButtons();
 }
 
+function drawBackground(lv, theme){
+  ctx.fillStyle=theme.bg; ctx.fillRect(0,0,W,H);
+  if(lv===0) drawUrbanBg(theme);
+  else if(lv===1) drawNatureBg(theme);
+  else drawCaveBg(theme);
+}
+
+function drawUrbanBg(theme){
+  // distant buildings
+  ctx.fillStyle=shade(theme.bg,0.2);
+  for(let i=-1;i<10;i++){
+    const x=i*80-((camX*0.3)%80);
+    const h=60+((i*37)%40);
+    ctx.fillRect(x,H-h-40,60,h);
+  }
+  // metal fences
+  ctx.fillStyle=shade(theme.bg,0.4);
+  for(let x=-((camX*0.6)%40); x<W; x+=40){
+    ctx.fillRect(x,120,2,40);
+    ctx.fillRect(x+20,120,2,40);
+  }
+  ctx.fillRect(0,120,W,2);
+  ctx.fillRect(0,140,W,2);
+}
+
+function drawNatureBg(theme){
+  // rolling hills
+  ctx.fillStyle=shade(theme.bg,0.2);
+  for(let i=-1;i<8;i++){
+    const x=i*100-((camX*0.2)%100);
+    ctx.beginPath();
+    ctx.arc(x+50,150,80,Math.PI,0);
+    ctx.fill();
+  }
+  // rocks
+  ctx.fillStyle=shade(theme.ground,-0.2);
+  for(let x=-((camX*0.6)%60); x<W; x+=60){
+    ctx.fillRect(x,150,20,10);
+  }
+  // olive trees
+  for(let x=-((camX*0.4)%120); x<W; x+=120){
+    ctx.fillStyle='#5d3'; ctx.fillRect(x+8,110,4,20);
+    ctx.fillStyle='#394'; ctx.beginPath(); ctx.arc(x+10,108,10,0,Math.PI*2); ctx.fill();
+  }
+}
+
+function drawCaveBg(theme){
+  ctx.fillStyle=shade(theme.bg,-0.2);
+  for(let i=-1;i<10;i++){
+    const x=i*40-((camX*0.2)%40);
+    const h=20+((i*53)%80);
+    ctx.fillRect(x,0,40,h);
+    ctx.fillRect(x,160-h,40,h);
+  }
+}
+
 function drawPlay(){
   const theme=themes[state.level];
-  // parallax bg
-  ctx.fillStyle=theme.bg; ctx.fillRect(0,0,W,H);
-  ctx.fillStyle=shade(theme.bg,0.3); for(let i=0;i<5;i++){ ctx.fillRect(i*80 - ((camX*0.3)%80), 20+i*10, 60,2) }
+  drawBackground(state.level, theme);
   // ground/platforms
   ctx.fillStyle=theme.ground; for(const p of level.platforms){ ctx.fillRect(p.x-camX,p.y,p.w,p.h) }
   // pickups


### PR DESCRIPTION
## Summary
- Diferenciar la generación de plataformas para cada nivel
- Añadir fondos específicos: urbano con edificios y vallas, campo con colinas y olivos, y cueva rocosa oscura
- Integrar nuevo dibujado de fondos en la fase de juego

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d5e96818832e880725c4a8499ff9